### PR TITLE
ci: restrict default workflow token permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ name: Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   github_release:
     name: GitHub Release


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to workflows that omitted one, so the default `GITHUB_TOKEN` carries only the scope the workflow needs. Jobs that declare their own `permissions:` block are unaffected (job-level blocks override the top-level one), and the org default token is already read-only, so this is behavior-preserving.

Refs inference-gateway/.github#96