### PR TITLE
ci: add deterministic schemas type sync

### DIFF
--- a/.github/workflows/schemas-sync.yml
+++ b/.github/workflows/schemas-sync.yml
@@ -14,6 +14,11 @@ on:
         required: false
         type: string
         default: ''
+      dry_run:
+        description: 'Preview the regeneration diff in the job summary without opening/updating a PR'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -24,4 +29,5 @@ jobs:
     with:
       language: python
       ref: ${{ inputs.ref }}
+      dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/.github/workflows/schemas-sync.yml
+++ b/.github/workflows/schemas-sync.yml
@@ -1,0 +1,27 @@
+---
+name: Schemas Sync
+
+# Thin caller of the org reusable deterministic schemas->types sync. Runs
+# `task oas-sync SCHEMAS_REF=<ref>` and opens/updates an idempotent PR on the
+# fixed `schemas-sync` branch. Dispatched per repo, or fanned out from
+# inference-gateway/schemas' sync-downstream.yml.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'schemas ref to sync (refs/tags/vX.Y.Z, refs/heads/main, or a SHA). Empty = latest schemas release.'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    uses: inference-gateway/.github/.github/workflows/schemas-sync.yml@main
+    with:
+      language: python
+      ref: ${{ inputs.ref }}
+    secrets: inherit

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,7 +2,8 @@
 version: "3"
 
 vars:
-  OPENAPI_URL: https://raw.githubusercontent.com/inference-gateway/schemas/refs/heads/main/openapi.yaml
+  SCHEMAS_REF: '{{.SCHEMAS_REF | default "refs/heads/main"}}'
+  OPENAPI_URL: https://raw.githubusercontent.com/inference-gateway/schemas/{{.SCHEMAS_REF}}/openapi.yaml
   PYTHON_VERSION: "3.13"
 
 tasks:
@@ -17,7 +18,7 @@ tasks:
       - pip install -e ".[dev]"
 
   oas-download:
-    desc: Download latest OpenAPI specification from inference-gateway repository
+    desc: Download OpenAPI specification (pin with SCHEMAS_REF=refs/tags/vX.Y.Z, a branch ref, or a SHA)
     cmds:
       - echo "Downloading OpenAPI spec from {{.OPENAPI_URL}}..."
       - curl -sSL -o openapi.yaml "{{.OPENAPI_URL}}"
@@ -64,6 +65,11 @@ tasks:
         --use-title-as-name
       - echo "✅ Models generated successfully"
       - task: format
+
+  oas-sync:
+    desc: Fetch the OpenAPI spec (pin with SCHEMAS_REF) and regenerate models
+    cmds:
+      - task: generate
 
   format:
     desc: Format code with black and isort

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,7 +21,7 @@ tasks:
     desc: Download OpenAPI specification (pin with SCHEMAS_REF=refs/tags/vX.Y.Z, a branch ref, or a SHA)
     cmds:
       - echo "Downloading OpenAPI spec from {{.OPENAPI_URL}}..."
-      - curl -sSL -o openapi.yaml "{{.OPENAPI_URL}}"
+      - curl -fsSL -o openapi.yaml "{{.OPENAPI_URL}}"
       - echo "✅ OpenAPI spec downloaded successfully"
 
   oas-validate:


### PR DESCRIPTION
## Summary

Part of the org-wide deterministic schemas→types sync (replaces the manual per-repo regeneration chore):

- Standardizes the Taskfile sync contract: `oas-download` now accepts `SCHEMAS_REF` (`refs/tags/vX.Y.Z`, a branch ref, or a SHA; default `refs/heads/main`), and `oas-sync` chains download + codegen as the single entry point.
- Threads `SCHEMAS_REF` through the existing `OPENAPI_URL` var; `oas-sync` reuses the existing `oas-download → oas-validate → generate` dep chain.
- Adds `.github/workflows/schemas-sync.yml`, a thin caller of the org reusable workflow `inference-gateway/.github/.github/workflows/schemas-sync.yml@main`. It regenerates types against a pinned schemas ref and opens/updates an idempotent PR on the fixed `schemas-sync` branch. Dispatch it from this repo's Actions tab, or fan out to all consumers via `sync-downstream.yml` in `inference-gateway/schemas`.

Verified locally: `task oas-sync SCHEMAS_REF=refs/tags/v0.10.0` downloads the pinned spec and regenerates deterministically.

## Impacted repos

Same rollout lands in: `inference-gateway/.github` (reusable workflow; SDK LLM drift audit retired, docs audit kept), `sdk`, `python-sdk`, `rust-sdk`, `typescript-sdk`, `inference-gateway`, and `schemas` (fan-out dispatcher).
